### PR TITLE
feat: bump parser and add package-lock

### DIFF
--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{ asyncapi.info().title() | kebabCase }}",
+  "version": "{{ asyncapi.info().version() }}",
+  "lockfileVersion": 1
+}

--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
     "start": "node src/api/index.js"
   },
   "dependencies": {
-    "asyncapi-parser": "0.x",
+    "@asyncapi/parser": "^1.2.0",
     "express": "4.17.1",
     "express-ws": "4.0.0",
     "node-yaml-config": "0.0.4"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- use parser from new scope
- package-lock that is necessary if we want automated bump, what do you think about it?

**Related issue(s)**
See also https://github.com/asyncapi/parser-js/pull/208