### PR TITLE
feat: add routes for sub operation and fix sematics

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -24,15 +24,15 @@ function getOperationIds(channel) {
     const id = opName === 'subscribe' ? channel.subscribe().id() : channel.publish().id();
     if (!id) throw new Error(noOperationIdError);
 
-    list += `, ${id}`;
+    return `, ${id}`;
   }
 
   if (channel.hasSubscribe()) {
-    parseOperationId(channel, 'subscribe');
+    list += parseOperationId(channel, 'subscribe');
   }
 
   if (channel.hasPublish()) {
-    parseOperationId(channel, 'publish');
+    list += parseOperationId(channel, 'publish');
   }
 
   return list.substring(1);

--- a/filters/all.js
+++ b/filters/all.js
@@ -17,24 +17,20 @@ filter.pathResolve = pathResolve;
 /*
  * returns comma separated string of all operationIds of a given channel
 */
+const parseOperationId = (channel, opName) => {
+  const id = opName === 'subscribe' ? channel.subscribe().id() : channel.publish().id();
+  if (!id) throw new Error('This template requires operationId to be set in every operation.');
+  return id;
+}
+
 function getOperationIds(channel) {
-  const noOperationIdError = 'This template requires operationId to be set in every operation.'
-  let list = '';
-  let parseOperationId = (channel, opName) => {
-    const id = opName === 'subscribe' ? channel.subscribe().id() : channel.publish().id();
-    if (!id) throw new Error(noOperationIdError);
-
-    return `, ${id}`;
-  }
-
+  const list = [];
   if (channel.hasSubscribe()) {
-    list += parseOperationId(channel, 'subscribe');
+    list.push(parseOperationId(channel, 'subscribe'));
   }
-
   if (channel.hasPublish()) {
-    list += parseOperationId(channel, 'publish');
+    list.push(parseOperationId(channel, 'publish'));
   }
-
-  return list.substring(1);
+  return list.filter(Boolean).join(', ');
 }
 filter.getOperationIds = getOperationIds;

--- a/filters/all.js
+++ b/filters/all.js
@@ -13,3 +13,28 @@ function pathResolve(pathName, basePath = '/') {
   return path.resolve(basePath, pathName);
 }
 filter.pathResolve = pathResolve;
+
+/*
+ * returns comma separated string of all operationIds of a given channel
+*/
+function getOperationIds(channel) {
+  const noOperationIdError = 'This template requires operationId to be set in every operation.'
+  let list = '';
+  let parseOperationId = (channel, opName) => {
+    const id = opName === 'subscribe' ? channel.subscribe().id() : channel.publish().id();
+    if (!id) throw new Error(noOperationIdError);
+
+    list += `, ${id}`;
+  }
+
+  if (channel.hasSubscribe()) {
+    parseOperationId(channel, 'subscribe');
+  }
+
+  if (channel.hasPublish()) {
+    parseOperationId(channel, 'publish');
+  }
+
+  return list.substring(1);
+}
+filter.getOperationIds = getOperationIds;

--- a/template/index.html
+++ b/template/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    Open your browser console to see the logs.
+    <h1>Open your browser console to see the logs and details of API you can use to talk to the server.</h1>
     <script>
     let connection;
 

--- a/template/src/api/routes.js
+++ b/template/src/api/routes.js
@@ -2,8 +2,8 @@ const util = require('util');
 const { Router } = require('express');
 const { yellow } = require('../lib/colors');
 {%- for channelName, channel in asyncapi.channels() -%}
-{%- if channel.hasSubscribe() %}
-{%- if channel.subscribe().id() === undefined -%}
+{%- if channel.hasPublish() %}
+{%- if channel.publish().id() === undefined -%}
 { { 'This template requires operationId to be set in every operation.' | logError }}
 {%- endif %}
 const {{ channelName | camelCase }}Service = require('./services/{{ channelName | kebabCase }}');
@@ -12,10 +12,10 @@ const {{ channelName | camelCase }}Service = require('./services/{{ channelName 
 const router = Router();
 module.exports = router;
 {% for channelName, channel in asyncapi.channels() -%}
-{%- if channel.hasSubscribe() %}
-  {%- if channel.subscribe().summary() %}
+{%- if channel.hasPublish() %}
+  {%- if channel.publish().summary() %}
 /**
- * {{ channel.subscribe().summary() }}
+ * {{ channel.publish().summary() }}
  */
   {%- endif %}
 router.ws('{{ channelName | pathResolve }}', async (ws, req) => {
@@ -23,7 +23,7 @@ router.ws('{{ channelName | pathResolve }}', async (ws, req) => {
     const path = req.path.substr(0, req.path.length - '/.websocket'.length);
     console.log(`${yellow(path)} message was received:`);
     console.log(util.inspect(msg, { depth: null, colors: true }));
-    await {{ channelName | camelCase }}Service.{{ channel.subscribe().id() }}(ws, { message: msg, path, query: req.query });
+    await {{ channelName | camelCase }}Service.{{ channel.publish().id() }}(ws, { message: msg, path, query: req.query });
   });
 });
 

--- a/template/src/api/routes.js
+++ b/template/src/api/routes.js
@@ -9,38 +9,19 @@ const { {{ allOperationIds }} } = require('./services/{{ channelName | kebabCase
 const router = Router();
 module.exports = router;
 {% for channelName, channel in asyncapi.channels() -%}
-{%- if channel.hasPublish() %}
-  {%- if channel.publish().summary() %}
-/**
- * {{ channel.publish().summary() }}
- */
-  {%- endif %}
 router.ws('{{ channelName | pathResolve }}', async (ws, req) => {
   const path = pathParser(req.path);
   console.log(`${yellow(path)} client connected.`);
+  {%- if channel.hasSubscribe() %}
+  await {{ channel.subscribe().id() }}(ws);
+  {%- endif %}
 
+  {%- if channel.hasPublish() %}
   ws.on('message', async (msg) => {
-    const path = pathParser(req.path);
     console.log(`${yellow(path)} message was received:`);
     console.log(util.inspect(msg, { depth: null, colors: true }));
     await {{ channel.publish().id() }}(ws, { message: msg, path, query: req.query });
   });
-});
-{%- endif %}
-{% endfor -%}
-
-{% for channelName, channel in asyncapi.channels() -%}
-{%- if channel.hasSubscribe() %}
-  {%- if channel.subscribe().summary() %}
-/**
- * {{ channel.subscribe().summary() }}
- */
   {%- endif %}
-router.ws('{{ channelName | pathResolve }}', async (ws, req) => {
-    const path = pathParser(req.path);
-    console.log(`${yellow(path)} client connected.`);
-    await {{ channel.subscribe().id() }}(ws);
 });
-
-{%- endif %}
 {% endfor -%}

--- a/template/src/api/services/$$channel$$.js
+++ b/template/src/api/services/$$channel$$.js
@@ -3,21 +3,9 @@ const service = module.exports = {};
 /**
  * {{ channel.subscribe().summary() }}
  * @param {object} ws WebSocket connection.
- * @param {object} options
- * @param {%raw%}{{%endraw%}{{channel.subscribe().message(0).payload().type()}}{%raw%}}{%endraw%} options.message The message to send.
-{%- if channel.subscribe().message(0).headers() %}
-{%- for fieldName, field in channel.subscribe().message(0).headers().properties() %}
-{{ field | docline(fieldName, 'options.message.headers') }}
-{%- endfor %}
-{%- endif %}
-{%- if channel.subscribe().message(0).payload() %}
-{%- for fieldName, field in channel.subscribe().message(0).payload().properties() %}
-{{ field | docline(fieldName, 'options.message.payload') }}
-{%- endfor %}
-{%- endif %}
  */
-service.{{ channel.subscribe().id() }} = async (ws, { message }) => {
-  ws.send('Message from the server: Implement your business logic here.');
+service.{{ channel.subscribe().id() }} = async (ws) => {
+  ws.send('Message from the server: Implement here your business logic that sends messages to a client after it connects.');
 };
 
 {%- endif %}
@@ -40,8 +28,8 @@ service.{{ channel.subscribe().id() }} = async (ws, { message }) => {
 {%- endfor %}
 {%- endif %}
  */
-service.{{ channel.publish().id() }} = async (ws, { message, path }) => {
-  ws.send('Message from the server: Implement your business logic here.');
+service.{{ channel.publish().id() }} = async (ws, { message, path, query }) => {
+  ws.send('Message from the server: Implement here your business logic that reacts on messages sent from a client.');
 };
 
 {%- endif %}

--- a/template/src/api/services/$$channel$$.js
+++ b/template/src/api/services/$$channel$$.js
@@ -1,34 +1,10 @@
 const service = module.exports = {};
-{% if channel.hasPublish() %}
-/**
- * {{ channel.publish().summary() }}
- * @param {object} ws WebSocket connection.
- * @param {object} options
- * @param {%raw%}{{%endraw%}{{channel.publish().message(0).payload().type()}}{%raw%}}{%endraw%} options.message The message to send.
-{%- if channel.publish().message(0).headers() %}
-{%- for fieldName, field in channel.publish().message(0).headers().properties() %}
-{{ field | docline(fieldName, 'options.message.headers') }}
-{%- endfor %}
-{%- endif %}
-{%- if channel.publish().message(0).payload() %}
-{%- for fieldName, field in channel.publish().message(0).payload().properties() %}
-{{ field | docline(fieldName, 'options.message.payload') }}
-{%- endfor %}
-{%- endif %}
- */
-service.{{ channel.publish().id() }} = async (ws, { message }) => {
-  ws.send('Message from the server: Implement your business logic here.');
-};
-
-{%- endif %}
-{%- if channel.hasSubscribe() %}
+{% if channel.hasSubscribe() %}
 /**
  * {{ channel.subscribe().summary() }}
  * @param {object} ws WebSocket connection.
  * @param {object} options
- * @param {string} options.path The path in which the message was received.
- * @param {object} options.query The query parameters used when connecting to the server.
- * @param {%raw%}{{%endraw%}{{channel.subscribe().message(0).payload().type()}}{%raw%}}{%endraw%} options.message The received message.
+ * @param {%raw%}{{%endraw%}{{channel.subscribe().message(0).payload().type()}}{%raw%}}{%endraw%} options.message The message to send.
 {%- if channel.subscribe().message(0).headers() %}
 {%- for fieldName, field in channel.subscribe().message(0).headers().properties() %}
 {{ field | docline(fieldName, 'options.message.headers') }}
@@ -40,7 +16,31 @@ service.{{ channel.publish().id() }} = async (ws, { message }) => {
 {%- endfor %}
 {%- endif %}
  */
-service.{{ channel.subscribe().id() }} = async (ws, { message, path }) => {
+service.{{ channel.subscribe().id() }} = async (ws, { message }) => {
+  ws.send('Message from the server: Implement your business logic here.');
+};
+
+{%- endif %}
+{%- if channel.hasPublish() %}
+/**
+ * {{ channel.publish().summary() }}
+ * @param {object} ws WebSocket connection.
+ * @param {object} options
+ * @param {string} options.path The path in which the message was received.
+ * @param {object} options.query The query parameters used when connecting to the server.
+ * @param {%raw%}{{%endraw%}{{channel.publish().message(0).payload().type()}}{%raw%}}{%endraw%} options.message The received message.
+{%- if channel.publish().message(0).headers() %}
+{%- for fieldName, field in channel.publish().message(0).headers().properties() %}
+{{ field | docline(fieldName, 'options.message.headers') }}
+{%- endfor %}
+{%- endif %}
+{%- if channel.publish().message(0).payload() %}
+{%- for fieldName, field in channel.publish().message(0).payload().properties() %}
+{{ field | docline(fieldName, 'options.message.payload') }}
+{%- endfor %}
+{%- endif %}
+ */
+service.{{ channel.publish().id() }} = async (ws, { message, path }) => {
   ws.send('Message from the server: Implement your business logic here.');
 };
 

--- a/template/src/lib/path.js
+++ b/template/src/lib/path.js
@@ -1,0 +1,3 @@
+module.exports.pathParser = (path) => {
+  return path.substr(0, path.length - '/.websocket'.length);
+};


### PR DESCRIPTION
**Description**

- Template uses publish and subscribe in a wrong way 😅 I did not notice it first when using [this chat-like model](https://raw.githubusercontent.com/asyncapi/generator/v1.4.0/test/docs/ws.yml) as messages there are the same, so I did not care much first. Other problem is `operationId` that in the file focuses on the client, but on the server you do not want to handle incoming messages with a service called `sendEcho` but `onEcho`. OMG this is so confusing, even for WebSocket where I thought it won't be. In other words, the code that I generate for the service should have logic that reacts to the message as part of the service generated based on the `publish` operation, not `subscribe`.
- add routers for `subscribe` operations, where client connects to given channel and there needs to be a generated code that links route to generated service. Looking on below file, there needs to be a route generated that when client connects to `travel/status` then service called `sendTravelInfoRequest` is invoked.
- I did not focus much on code quality for filters and nunjucks as it anyways needs replacement with react

my file:
```yml
asyncapi: 2.0.0

info:
  title: Shrek App
  version: '1.0.0'
  description: |
    Have some fun with AsyncAPI and WebSocket and define an interface for ... Shrek
    ![](https://media.giphy.com/media/10Ug6rDDuG3YoU/giphy-downsized.gif)
servers:
  swamp:
    url: localhost
    protocol: ws
channels:
  /chat:
    subscribe:
      summary: Client can receive chat messages.
      operationId: subChatMessage
      message:
        $ref: '#/components/messages/chatMessage'
    publish:
      summary: Client can send chat messages.
      operationId: pubChatMessage
      message:
        $ref: '#/components/messages/chatMessage'
  /travel/status:
    subscribe:
      summary: Client can receive travel info status.
      operationId: subTravelInfo
      message:
        $ref: '#/components/messages/travelInfo'

components:
  messages:
    chatMessage:
      summary: Message that you send or receive from chat
      payload:
        type: string
    travelInfo:
      summary: Message that contains information about travel status.
      payload:
        type: object
        properties:
          destination:
            description: Name of travel destination.
            type: string
          distance:
            description: How much distance left to the target.
            type: string
          arrival:
            description: Time left to get there.
            type: string
```

with this PR routs are generated for all, pub and sub, so even if there are no messages sent from client I already have route where I can log that connection from client is set and then have connection with my service where I can start sending some messages.
```js
const util = require('util');
const { Router } = require('express');
const { pathParser } = require('../lib/path');
const { yellow } = require('../lib/colors');
const {  subChatMessage, pubChatMessage } = require('./services/chat');
const {  subTravelInfo } = require('./services/travel-status');
const router = Router();
module.exports = router;

router.ws('/chat', async (ws, req) => {
  const path = pathParser(req.path);
  console.log(`${yellow(path)} client connected.`);
  await subChatMessage(ws);
  
  ws.on('message', async (msg) => {
    console.log(`${yellow(path)} message was received:`);
    console.log(util.inspect(msg, { depth: null, colors: true }));
    await pubChatMessage(ws, { message: msg, path, query: req.query });
  });
  
});

router.ws('/travel/status', async (ws, req) => {
  const path = pathParser(req.path);
  console.log(`${yellow(path)} client connected.`);
  await subTravelInfo(ws);
  
});
```

as a result I can write just a login for my Travel service that after client connects, it starts getting my generated messages
```js
const service = module.exports = {};
const dummyjson = require('dummy-json');

/**
 * Client can receive travel info status.
 * @param {object} ws WebSocket connection.
 */
service.sendTravelInfoRequest = async (ws) => {
  (function myLoop (i) {
    setTimeout(() => {
      ws.send(generateResponse());
      if (--i) myLoop(i);
    }, 1000);
  }(100));  

  function generateResponse() {
    const template = `{
      "destination": "{{city}}",
      "arrival": "{{int 2 6}}h",
      "distance": "{{int 18 65}}km"
    }`;
    return dummyjson.parse(template);
  }
};
```