### PR TITLE
feat: add node-js streaming client for ws template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 - [Specification requirements](#specification-requirements)
 - [Supported protocols](#supported-protocols)
 - [How to use the template](#how-to-use-the-template)
-  * [CLI](#cli)
+  * [ Interactive Server/Client](#isc)
+  * [ Data Streaming Client](#dsc)
 - [Template configuration](#template-configuration)
 - [Custom hooks that you can disable](#custom-hooks-that-you-can-disable)
 - [Development](#development)
@@ -21,9 +22,10 @@
 
 ## Overview
 
-This template generates two resources related to WebSockets:
+This template generates the following resources related to WebSockets:
 - Server application with WebSocket endpoint based on [Express.js](https://expressjs.com/)
 - Client HTML file with simple scripts that give you a basic API to talk to the server
+- Client node-js script to connect and receive data from a websocket data streaming service
 
 Other files are for the setup of developer environment, like `.editorconfig` or `.eslint`.
 
@@ -51,7 +53,7 @@ Property name | Reason | Fallback | Default
 
 This template must be used with the AsyncAPI Generator. You can find all available options [here](https://github.com/asyncapi/generator/).
 
-### CLI
+### Interactive Server/Client
 
 ```bash
 # Install the AsyncAPI Generator
@@ -89,6 +91,30 @@ send({ greet: 'Hello from client' })
 
 # You should see the sent message in the logs of the previously started server
 ```
+
+### One-Way Data Streaming Client
+
+In case of one-way data streaming use case, A client program establishes the websocket connection with the specified service and starts to receive data in a streaming fashion. In this usage, a single channel is assumed in the service configuration and only subscribe operation is supported for the channel. To generate the data streaming client, modify the test/streaming.yaml accordingly:
+  * specify the service host url
+  * specify the channel and bindings associated with the channel
+  * specify the message subscribed
+
+
+```bash
+# Install the AsyncAPI Generator
+npm install -g @asyncapi/generator
+
+# Run generation
+ag test/streaming.yaml @asyncapi/nodejs-ws-template -o output -p server=localhost
+
+##
+## Start the client
+##
+
+# Go to the generated server
+cd output
+node client.js
+
 
 ## Template configuration
 
@@ -132,6 +158,8 @@ There are two ways you can work on template development:
   # assumption is that generator sources are cloned on the same level as the template
   ../generator/cli.js https://raw.githubusercontent.com/asyncapi/generator/v1.4.0/test/docs/ws.yml ./ -o output
   ```
+
+
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 - [Specification requirements](#specification-requirements)
 - [Supported protocols](#supported-protocols)
 - [How to use the template](#how-to-use-the-template)
-  * [ Interactive Server/Client](#isc)
-  * [ Data Streaming Client](#dsc)
+  * [Interactive Server Client](#interactive-server-client)
+  * [Data Streaming Client](#data-streaming-client)
 - [Template configuration](#template-configuration)
 - [Custom hooks that you can disable](#custom-hooks-that-you-can-disable)
 - [Development](#development)
@@ -53,7 +53,7 @@ Property name | Reason | Fallback | Default
 
 This template must be used with the AsyncAPI Generator. You can find all available options [here](https://github.com/asyncapi/generator/).
 
-### Interactive Server/Client
+### Interactive Server Client
 
 ```bash
 # Install the AsyncAPI Generator
@@ -92,7 +92,7 @@ send({ greet: 'Hello from client' })
 # You should see the sent message in the logs of the previously started server
 ```
 
-### One-Way Data Streaming Client
+### Data Streaming Client
 
 In case of one-way data streaming use case, A client program establishes the websocket connection with the specified service and starts to receive data in a streaming fashion. In this usage, a single channel is assumed in the service configuration and only subscribe operation is supported for the channel. To generate the data streaming client, modify the test/streaming.yaml accordingly:
   * specify the service host url
@@ -114,7 +114,7 @@ ag test/streaming.yaml @asyncapi/nodejs-ws-template -o output -p server=localhos
 # Go to the generated server
 cd output
 node client.js
-
+```
 
 ## Template configuration
 

--- a/template/client.js
+++ b/template/client.js
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////
+//
+// {{ asyncapi.info().title() }}: streaming client example
+//
+////////////////////////////////////////////////////////////////
+const WebSocket = require('ws')
+
+////////////////////////////////////////////////////////////////
+//
+// This client handles the one-way websocket streaming use case
+// It assumes only one channel on the server!
+// It assumes only subscribe oepration in the channel!
+// It supports query parameters such as ?begin=now&format=avro
+//
+////////////////////////////////////////////////////////////////
+{%- set supported = false %}
+{%- set numChannels = asyncapi.channelNames() | length %}
+{%- set user_func = "processData" %}
+{%- set url_queryString = "" %}
+{%- set url_queryDelimiter = "?" %}
+{%- set url_protocol = asyncapi.server(params.server).protocol() %}
+{%- set url_server = asyncapi.server(params.server).url() %}
+{%- set url_path = asyncapi.channelNames()[0] %}
+{%- set msg_type = "" %}
+
+{%- if numChannels != 1 %}
+  // Not Supported, one channel streaming client only
+  {%- set supported = false %}
+{%- else %}
+  {%- for channelName, channel in asyncapi.channels() %}
+    {%- if channel.hasPublish() %}
+      // Not Supported, subscribe operation only
+      {%- set supported = false %}
+    {%- else %}
+      {%- if channel.hasSubscribe() %}
+        {%- set supported = true %}
+        {%- set user_func = channel.subscribe().id() %}
+        {%- if channel.hasBindings("ws") %}
+          {%- set ws_binding = channel.binding("ws") %}
+          {%- if ws_binding["query"]["properties"] %}
+            {%- for propKey, propValue in ws_binding["query"]["properties"] %}
+              {%- set sValue = "" %}
+              {%- if propValue %}
+                {%- if propValue["default"] %}
+                  {%- set sValue = propValue["default"] %}
+                {%- else %}
+                  {%- set sValue = propValue %}
+                {%- endif %}
+                {%- set url_queryString = url_queryString + url_queryDelimiter + propKey + "=" + sValue %}
+              {%- endif %}
+              {%- if url_queryDelimiter == "?" %}
+                {%- set url_queryDelimiter = "&" %}
+              {%- endif %}
+            {%- endfor %}
+          {%- endif %}
+        {%- endif %}
+        {%- set msg_type = channel.subscribe().message().payload().type() %}
+      {%- endif %}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
+
+{%- if supported %}
+
+////////////////////////////////////////////////////////////////
+//
+// generic data processing with the websocket service,
+// assume an array of json objects.
+//
+////////////////////////////////////////////////////////////////
+const {{user_func}} = (wsClient) => {
+    wsClient.on('message', function message(data) {
+        console.log('received some data:')
+        const records = eval(data.toString())
+{%- if msg_type == "array" %}
+        for (var i = 0; i < records.length; i++) {
+	    console.log(records[i]);
+            //data processing, implement user logic here. 
+        }
+{%- else %}
+        console.log(records);
+        //data processing, implement user logic here. 
+{%- endif %}
+    });
+    wsClient.on('error', (err) => {
+        console.log(err.toString());
+    });
+}
+
+////////////////////////////////////////////////////////////////
+//
+// main entry point for the example client:
+// asyncapi yaml definition is parsed to provide service
+// access URL and a dedicated websocket connection is
+// created to stream data from the service.
+//
+////////////////////////////////////////////////////////////////
+const init = async () =>{
+    const serviceURL = '{{url_protocol}}://{{url_server}}{{url_path}}{{url_queryString}}'
+
+    console.log(" ");
+    console.log("Establishing websocket connection to: ");
+    console.log(serviceURL);
+    console.log(" ");
+
+    // establishing websocket connection to the service
+    const wsClient = new WebSocket(serviceURL);
+
+    console.log(" ");
+    console.log("Start streaming data from the service ...");
+    console.log(" ");
+
+    // now start the client processing    
+    {{user_func}}(wsClient)
+}
+
+init()
+
+{% else %}
+//
+// the use case is NOT supported in this client.
+//
+{% endif %}

--- a/test/streaming.yaml
+++ b/test/streaming.yaml
@@ -1,0 +1,48 @@
+asyncapi: '2.2.0'
+info:
+  title: data streaming example API
+  version: '1.0.0'
+  description: |
+    allows clients to subscribe to a data streaming API
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  localhost:
+    url: admin:Welcome_1@localhost:9002
+    protocol: ws
+
+defaultContentType: application/json
+
+channels:
+  /services/v2/stream/stream1:
+    bindings:
+      ws:
+        bindingVersion: 0.1.0
+        query:
+          type: object
+          description: query parameter like begin=earliest
+          properties:
+            begin:
+              type: string
+              default: earliest
+              description: begin position to start streaming data
+    subscribe:
+      summary: data records
+      operationId: onRecords
+      message:
+        $ref : '#/components/messages/userRecords'
+
+components:
+  messages:
+    userRecords:
+      name: userRecords
+      title: User Data Records
+      summary: array of user data records in json format
+      contentType: application/json
+      payload:
+        type: array
+        items:
+          type: object
+
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This request adds node-js streaming client support in websocket template for the asyncapi code generator. This allows users to generate a client.js script that can talk to a websocket streaming service. 
1. it adds template/client.js in template folder, which is the nunjunks template for code generation.
2. it adds test/streaming.ymal for testing purpose. It describe a simple websocket streaming service and allows the code generate to generate a example nodejs client.js.
3. it modifies README.md to add instructions on how to use the websocket streaming client

There are still a few TODOs, 
1. it currently supports basic auth in service URL, more advanced authentication/authorization bindings may need to be added.
2. secure websocket protocol support may need to be added
3. more complex and detailed data message definition and data validation may be needed. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->