### PR TITLE
feat: add streaming client for nodejs-ws-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 - [Specification requirements](#specification-requirements)
 - [Supported protocols](#supported-protocols)
 - [How to use the template](#how-to-use-the-template)
-  * [CLI](#cli)
+  * [Interactive Server Client](#interactive-server-client)
+  * [Data Streaming Client](#data-streaming-client)
 - [Template configuration](#template-configuration)
 - [Custom hooks that you can disable](#custom-hooks-that-you-can-disable)
 - [Development](#development)
@@ -21,9 +22,10 @@
 
 ## Overview
 
-This template generates two resources related to WebSockets:
+This template generates the following resources related to WebSockets:
 - Server application with WebSocket endpoint based on [Express.js](https://expressjs.com/)
 - Client HTML file with simple scripts that give you a basic API to talk to the server
+- Client node-js script to connect and receive data from a websocket data streaming service
 
 Other files are for the setup of developer environment, like `.editorconfig` or `.eslint`.
 
@@ -51,7 +53,7 @@ Property name | Reason | Fallback | Default
 
 This template must be used with the AsyncAPI Generator. You can find all available options [here](https://github.com/asyncapi/generator/).
 
-### CLI
+### Interactive Server Client
 
 ```bash
 # Install the AsyncAPI Generator
@@ -88,6 +90,31 @@ listen('/echo')
 send({ greet: 'Hello from client' })
 
 # You should see the sent message in the logs of the previously started server
+```
+
+### Data Streaming Client
+
+In case of one-way data streaming use case, A client program establishes the websocket connection with the specified service and starts to receive data in a streaming fashion. In this usage, a single channel is assumed in the service configuration and only subscribe operation is supported for the channel. To generate the data streaming client, modify the test/streaming.yaml accordingly:
+  * specify the service host url
+  * specify the channel and bindings associated with the channel
+  * specify the message subscribed
+
+
+```bash
+# Install dependecies and the AsyncAPI Generator
+npm install
+npm install -g @asyncapi/generator
+
+# Run generation
+ag test/streaming.yaml @asyncapi/nodejs-ws-template -o output -p server=localhost
+
+##
+## Start the client
+##
+
+# Go to the generated output folder
+cd output
+node client.js
 ```
 
 ## Template configuration
@@ -132,6 +159,8 @@ There are two ways you can work on template development:
   # assumption is that generator sources are cloned on the same level as the template
   ../generator/cli.js https://raw.githubusercontent.com/asyncapi/generator/v1.4.0/test/docs/ws.yml ./ -o output
   ```
+
+
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ ag test/streaming.yaml @asyncapi/nodejs-ws-template -o output -p server=localhos
 ## Start the client
 ##
 
-# Go to the generated output folder
+# Go to generated output folder
 cd output
 node client.js
 ```

--- a/template/client.js
+++ b/template/client.js
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////
+//
+// {{ asyncapi.info().title() }}: streaming client example
+//
+////////////////////////////////////////////////////////////////
+const WebSocket = require('ws')
+
+////////////////////////////////////////////////////////////////
+//
+// This client handles the one-way websocket streaming use case
+// It assumes only one channel in the server!
+// It assumes only subscribe oepration in the channel!
+// It supports query parameters such as ?begin=now&format=avro
+//
+////////////////////////////////////////////////////////////////
+{%- set supported = false %}
+{%- set numChannels = asyncapi.channelNames() | length %}
+{%- set userFunction = "processData" %}
+{%- set urlQueryString = "" %}
+{%- set urlQueryDelimiter = "?" %}
+{%- set urlProtocol = asyncapi.server(params.server).protocol() %}
+{%- set urlServer = asyncapi.server(params.server).url() %}
+{%- set urlPath = asyncapi.channelNames()[0] %}
+{%- set msgType = "" %}
+
+{%- if numChannels != 1 %}
+  // Not Supported, one channel streaming client only
+  {%- set supported = false %}
+{%- else %}
+  {%- for channelName, channel in asyncapi.channels() %}
+    {%- if channel.hasPublish() %}
+      // Not Supported, subscribe operation only
+      {%- set supported = false %}
+    {%- else %}
+      {%- if channel.hasSubscribe() %}
+        {%- set supported = true %}
+        {%- set userFunction = channel.subscribe().id() %}
+        {%- if channel.hasBindings("ws") %}
+          {%- set ws_binding = channel.binding("ws") %}
+          {%- if ws_binding["query"]["properties"] %}
+            {%- for propKey, propValue in ws_binding["query"]["properties"] %}
+              {%- set sValue = "" %}
+              {%- if propValue %}
+                {%- if propValue["default"] %}
+                  {%- set sValue = propValue["default"] %}
+                {%- else %}
+                  {%- set sValue = propValue %}
+                {%- endif %}
+                {%- set urlQueryString = urlQueryString + urlQueryDelimiter + propKey + "=" + sValue %}
+              {%- endif %}
+              {%- if urlQueryDelimiter == "?" %}
+                {%- set urlQueryDelimiter = "&" %}
+              {%- endif %}
+            {%- endfor %}
+          {%- endif %}
+        {%- endif %}
+        {%- set msgType = channel.subscribe().message().payload().type() %}
+      {%- endif %}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
+
+{%- if supported %}
+
+////////////////////////////////////////////////////////////////
+//
+// generic data processing with the websocket service,
+// assume an array of json objects.
+//
+////////////////////////////////////////////////////////////////
+const {{userFunction}} = (wsClient) => {
+    wsClient.on('message', function message(data) {
+        console.log('received some data:')
+        const records = eval(data.toString())
+{%- if msgType == "array" %}
+        for (var i = 0; i < records.length; i++) {
+	    console.log(records[i]);
+            //data processing, implement user logic here. 
+        }
+{%- else %}
+        console.log(records);
+        //data processing, implement user logic here. 
+{%- endif %}
+    });
+    wsClient.on('error', (err) => {
+        console.log(err.toString());
+    });
+}
+
+////////////////////////////////////////////////////////////////
+//
+// main entry point for the example client:
+// asyncapi yaml definition is parsed to provide service
+// access URL and a dedicated websocket connection is
+// created to stream data from the service.
+//
+////////////////////////////////////////////////////////////////
+const init = async () =>{
+    const serviceURL = '{{urlProtocol}}://{{urlServer}}{{urlPath}}{{urlQueryString}}'
+
+    console.log(" ");
+    console.log("Establishing websocket connection to: ");
+    console.log(serviceURL);
+    console.log(" ");
+
+    // establishing websocket connection to the service
+    const wsClient = new WebSocket(serviceURL);
+
+    console.log(" ");
+    console.log("Start streaming data from the service ...");
+    console.log(" ");
+
+    // now start the client processing    
+    {{userFunction}}(wsClient)
+}
+
+init()
+
+{% else %}
+//
+// the use case is NOT supported in this client.
+//
+{% endif %}

--- a/test/streaming.yaml
+++ b/test/streaming.yaml
@@ -1,0 +1,48 @@
+asyncapi: '2.2.0'
+info:
+  title: data streaming example API
+  version: '1.0.0'
+  description: |
+    allows clients to subscribe to a data streaming API
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  localhost:
+    url: admin:Welcome_1@localhost:9002
+    protocol: ws
+
+defaultContentType: application/json
+
+channels:
+  /services/v2/stream/stream1:
+    bindings:
+      ws:
+        bindingVersion: 0.1.0
+        query:
+          type: object
+          description: query parameter like begin=earliest
+          properties:
+            begin:
+              type: string
+              default: earliest
+              description: begin position to start streaming data
+    subscribe:
+      summary: data records
+      operationId: onRecords
+      message:
+        $ref : '#/components/messages/userRecords'
+
+components:
+  messages:
+    userRecords:
+      name: userRecords
+      title: User Data Records
+      summary: array of user data records in json format
+      contentType: application/json
+      payload:
+        type: array
+        items:
+          type: object
+
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This request adds nodejs-ws streaming client support in websocket template for the asyncapi code generator. This allows users to generate a client.js script that can communicate to a websocket streaming service.

    it adds template/client.js in template folder, which is the nunjunks template for code generation.
    it adds test/streaming.ymal for testing purpose. It describe a simple websocket streaming service and allows the code generate to generate a example nodejs client.js.
    it modifies README.md to add instructions on how to use the websocket streaming client

There are still a few TODOs,

    it currently supports basic auth in service URL, more advanced authentication/authorization bindings may need to be added.
    secure websocket protocol support may need to be added
    more complex and detailed data message definition and data validation may be needed.


- ...
- ...
- ...

**Related issue(s)**
`See also #182`