### PR TITLE
fix: update template to work with @asyncapi/parser 2.x

### DIFF
--- a/template/src/lib/asyncapi.js
+++ b/template/src/lib/asyncapi.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { parse } = require('@asyncapi/parser');
+const { Parser } = require('@asyncapi/parser');
+
+const parser = new Parser();
 
 let cached;
 
@@ -20,7 +22,7 @@ module.exports.init = async () => {
   }
 
   try {
-    cached = await parse(content);
+    cached = await parser.parse(content);
   } catch (e) {
     throw e;
   }

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -55,7 +55,9 @@ router.ws('/echo', async (ws, req) => {
 exports[`template integration test using generator should generate application files  3`] = `
 "const fs = require('fs');
 const path = require('path');
-const { parse } = require('@asyncapi/parser');
+const { Parser } = require('@asyncapi/parser');
+
+const parser = new Parser();
 
 let cached;
 
@@ -75,7 +77,7 @@ module.exports.init = async () => {
   }
 
   try {
-    cached = await parse(content);
+    cached = await parser.parse(content);
   } catch (e) {
     throw e;
   }


### PR DESCRIPTION
**Description**

- Updated the https://github.com/ivankahl/nodejs-ws-template/blob/master/template/src/lib/asyncapi.js file to use the new Parser API in 2.x

**Tests**

I updated the test snapshot as the template change. See integration test results below:

```
 PASS  test/integration.test.js
  template integration test using generator
    ✓ should generate application files  (660 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   6 passed, 6 total
Time:        3.067 s
Ran all test suites.
```

I tested the template by using it for my own project and checking the application runs and the WebSocket works. Please see test results below:

```
D:\Code\AsyncApiFoodDelivery
❯ ag asyncapi.yaml https://github.com/ivankahl/nodejs-ws-template -p server=dev -o ws-server --force-write


Done! ✨
Check out your shiny new generated files at D:\Code\AsyncApiFoodDelivery\ws-server.


D:\Code\AsyncApiFoodDelivery took 36s
❯ cd .\ws-server\

Code\AsyncApiFoodDelivery\ws-server is 📦 v1.0.0 via  v14.21.3 
❯ npm install
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!
npm WARN food-delivery-api@1.0.0 No repository field.
npm WARN food-delivery-api@1.0.0 No license field.

added 190 packages from 175 contributors and audited 190 packages in 19.415s

45 packages are looking for funding
  run `npm fund` for details

found 3 moderate severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details

Code\AsyncApiFoodDelivery\ws-server is 📦 v1.0.0 via  v14.21.3 took 21s
❯ npm run start

> food-delivery-api@1.0.0 start D:\Code\AsyncApiFoodDelivery\ws-server
> node src/api/index.js

Listening on port 3000
```

Proof that the WebSocket connection works:
![image](https://user-images.githubusercontent.com/5931577/228798607-4c12c8ff-16f9-4c44-a48e-c43dd7295e45.png)


**Related issue(s)**
Resolves #271 